### PR TITLE
fedora-bot: Add support for merging PRs

### DIFF
--- a/.github/workflows/poll-releases.yml
+++ b/.github/workflows/poll-releases.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Check for new releases
-        run: python3 fedora_bot.py -u imagebuilder-bot -p "${{ secrets.FEDORA_PASSWORD }}"
+        run: python3 fedora_bot.py --user imagebuilder-bot --password "${{ secrets.FEDORA_PASSWORD }}" --apikey "${{ secrets.FEDORA_APIKEY }}"
         shell: bash
         env:
           SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"


### PR DESCRIPTION
As packit is removing the create_pr option we need to take care of
merging the pull requests in Fedora's dist-git ourselves.

The api key expires in 2 years from now (2024-04-28).

The code was tested with this test repo/PR: https://pagure.io/merge_test/pull-request/1