### PR TITLE
Update readme and schedule

### DIFF
--- a/.github/workflows/poll-releases.yml
+++ b/.github/workflows/poll-releases.yml
@@ -4,7 +4,7 @@ name: "Fedora bot"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '*/30 * * * *'
 
 jobs:
   check:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Fedora Release Bot
 
-This is a very simplistic bot that periodically runs and checks for new releases of osbuild or osbuild-composer.
+This is a very simplistic bot (`fedora_bot.py`) that periodically runs and checks for new releases of osbuild or osbuild-composer.
 
 If it finds a new release it:
 
- * schedules builds in Koji
- * updates Bodhi
+ * merges open pull requests created by Packit
+ * schedules builds in Koji (to be replaced by Packit)
+ * updates Bodhi (to be replaced by Packit)
+
+ # Reminder Bot
+
+ The reminder bot (`reminder_bot.py`) sends notifications to the team's Slack channel about whose turn it is to be a foreperson.


### PR DESCRIPTION
Currently the fedora-bot runs almost a little too frequently, so drop that to every 30mins (consistent with centos-bot).
Also, we need to update the README as it doesn't reflect the capabilities of the bot anymore.