### PR TITLE
Check pr flags

### DIFF
--- a/fedora_bot.py
+++ b/fedora_bot.py
@@ -9,8 +9,6 @@ import os
 import re
 import pexpect
 import requests
-import json
-from urllib import request
 from slack_sdk.webhook import WebhookClient
 
 
@@ -87,53 +85,55 @@ def check_pull_request_flags(component, pr_id):
     As the test results (pagure flags) are not immediately available and there is no indication of running tests
     we have to hardcode the amount of test results to expect so we can verify all tests have passed.
     """
-    req = request.Request(f'https://src.fedoraproject.org/api/0/rpms/{component}/pull-request/{pr_id}/flag', method="GET") # returns test statuses
-    req.add_header('Content-Type', 'application/json')
-
+    req = None
     num_tests = { 'osbuild': 3,
                   'osbuild-composer': 2,
                   'koji-osbuild': 2 }
     test_results = []
     success = False
 
-    try:
-        result = request.urlopen(req)
-        content = result.read()
-        if content:
-            res = json.loads(content.decode('utf-8'))
-            for flag in res['flags']:
-                test_results.append(flag['status'])
+    while not req:
+        try: # fetch test status
+            req = requests.get(f'https://src.fedoraproject.org/api/0/rpms/{component}/pull-request/{pr_id}/flag')
+        except requests.exceptions.Timeout:
+            pass
+        except requests.exceptions.HTTPError as err:
+            msg_info(f"{str(e)}\nFailed to get flags for pull request '{pr_id}'.")
 
-            if len(test_results) != num_tests[component]:
-                msg_info(f"Only {len(test_results)}/{num_tests[component]} tests have run, let's try again later.")
-            elif 'failure' not in test_results:
-                    msg_ok(f"All {len(test_results)} tests passed so the pull-request can be merged.")
-                    success = True
+    res = req.json()
+    for flag in res['flags']:
+        test_results.append(flag['status'])
 
-    except Exception as e:
-        msg_info(f"{str(e)}\nFailed to get flags for pull request '{pr_id}'.")
+    if len(test_results) != num_tests[component]: # check if the expected number of tests passed
+        msg_info(f"Only {len(test_results)}/{num_tests[component]} tests have run, let's try again later.")
+    elif 'failure' not in test_results:
+        msg_ok(f"All {len(test_results)} tests passed so the pull-request can be merged.")
+        success = True
+    elif 'failure' in test_results:
+        msg_info(f"Pull request '{pr_id}' has {len(test_results)}/{num_tests[component]} failed tests and therefore cannot be auto-merged.")
+    else:
+        msg_error("Something is wrong - maybe the amount of tests have changed?")
 
     return success
 
 
 def merge_pull_request(args, component, pr_id):
     """Merge a single pull request"""
-    req = request.Request(f'https://src.fedoraproject.org/api/0/rpms/{component}/pull-request/{pr_id}/merge', method="POST")
-    req.add_header('Authorization', f'token {args.apikey}')
-
     url = f"https://src.fedoraproject.org/rpms/{component}/pull-request/{pr_id}"
 
-    try:
-        r = request.urlopen(req)
-        content = r.read()
-        if content:
-            res = json.loads(content.decode('utf-8'))
-            if res['message'] == "Changes merged!":
-                msg_ok(f"Merged pull request for {component}: {url}")
-            else:
-                msg_info(res)
-    except Exception as e:
-        msg_info(f"{str(e)}\nFailed to merge pull request for {component}: {url}")
+    while not req:
+        try: # fetch test status
+            req = requests.post(f'https://src.fedoraproject.org/api/0/rpms/{component}/pull-request/{pr_id}/merge', headers={'Authorization': f'token {args.apikey}'})
+        except requests.exceptions.Timeout:
+            pass
+        except requests.exceptions.HTTPError as err:
+            msg_info(f"{str(e)}\nFailed to merge pull request for {component}: {url}")
+
+    res = req.json()
+    if res['message'] == "Changes merged!":
+        msg_ok(f"Merged pull request for {component}: {url}")
+    else:
+        msg_info(res)
 
 
 def merge_open_pull_requests(args, component):
@@ -142,27 +142,27 @@ def merge_open_pull_requests(args, component):
      1. it was created by packit
      2. all tests have passed
     """
-    req = request.Request(f'https://src.fedoraproject.org/api/0/rpms/{component}/pull-requests?author=packit', method="GET") # returns open PRs created by packit
-    req.add_header('Content-Type', 'application/json')
+    req = None
 
-    try:
-        result = request.urlopen(req)
-        content = result.read()
-        if content:
-            res = json.loads(content.decode('utf-8'))
-            if res['total_requests'] == 0:
-                msg_ok(f"There are currently no open pull requests for {component}.")
-                return
+    while not req:
+        try: # fetch all open PRs created by packit
+            req = requests.get(f'https://src.fedoraproject.org/api/0/rpms/{component}/pull-requests?author=packit')
+        except requests.exceptions.Timeout:
+            pass
+        except requests.exceptions.HTTPError as err:
+            msg_info(f"{str(e)}\nFailed to get pull requests for '{component}'.")
 
-            msg_info(f"Found {res['total_requests']} open pull requests for {component}. Starting the merge train...")
+    res = req.json()
+    if res['total_requests'] == 0:
+        msg_ok(f"There are currently no open pull requests for {component}.")
+        return
 
-            for pr in res['requests']:
-                successful_checks = check_pull_request_flags(component, pr['id'])
-                if successful_checks:
-                    merge_pull_request(args, component, pr['id'])
+    msg_info(f"Found {res['total_requests']} open pull requests for {component}. Starting the merge train...")
 
-    except Exception as e:
-        msg_info(f"{str(e)}\nFailed to get pull requests for '{component}'.")
+    for pr in res['requests']:
+        successful_checks = check_pull_request_flags(component, pr['id'])
+        if successful_checks:
+            merge_pull_request(args, component, pr['id'])
 
 
 def update_bodhi(args, component, fedora):


### PR DESCRIPTION
In order to make the PRs that packit opens automatically useful we can check if all tests passed vs. just auto-merging the PR.

The tests are shown in Pagure's API as 'flags' (https://pagure.io/api/0/#pull_requests-tab) and we're querying their status, which can either be `success` or `failure`. Unfortunately there is no indication of whether tests are currently/still running, so we need to hardcode the amount of tests we expect so we don't prematurely merge a PR.