### PR TITLE
fedora_bot: Make slack notifications optional

### DIFF
--- a/fedora_bot.py
+++ b/fedora_bot.py
@@ -54,13 +54,16 @@ def run_command(argv):
 
 
 def slack_notify(message: str):
+    msg_ok(message)
+
     url = os.getenv('SLACK_WEBHOOK_URL')
+    if not url:
+        return
+
     github_server_url = os.getenv('GITHUB_SERVER_URL')
     github_repository = os.getenv('GITHUB_REPOSITORY')
     github_run_id = os.getenv('GITHUB_RUN_ID')
     github_url = f"{github_server_url}/{github_repository}/actions/runs/{github_run_id}"
-
-    msg_ok(message)
 
     webhook = WebhookClient(url)
 

--- a/reminder_bot.py
+++ b/reminder_bot.py
@@ -136,7 +136,6 @@ def send_reminder(components, slack_nicks, target_date, message: str):
 if __name__ == "__main__":
     """Main function"""
     components = ['osbuild-composer','osbuild']
-    url = os.getenv('SLACK_WEBHOOK_URL')
 
     parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("-y", "--year", help="Year to use to create yaml files for osbuild and osbuild-composer")


### PR DESCRIPTION
Skip slack notifications if `$SLACK_WEBHOOK_URL` is not set.

---

In Cockpit and in my own upstream projects we don't use slack, but at some point I'd like to use fedora-bot to auto-land packit PRs.