### PR TITLE
fedora-bot: Parameterize components

### DIFF
--- a/.github/workflows/poll-releases.yml
+++ b/.github/workflows/poll-releases.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Check for new releases
-        run: python3 fedora_bot.py --user imagebuilder-bot --password "${{ secrets.FEDORA_PASSWORD }}" --apikey "${{ secrets.FEDORA_APIKEY }}"
+        run: python3 fedora_bot.py --user imagebuilder-bot --password "${{ secrets.FEDORA_PASSWORD }}" --apikey "${{ secrets.FEDORA_APIKEY }}" --component osbuild:3 --component osbuild-composer:2 --component koji-osbuild:2
         shell: bash
         env:
           SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/fedora_bot.py
+++ b/fedora_bot.py
@@ -213,7 +213,7 @@ def get_latest_dist_git_release(component):
         lines = file.readlines()
         for line in lines:
             if line.startswith("Version:"):
-                version = re.search('[0-9]+', line)
+                version = re.search('[0-9.]+', line)
 
     os.chdir(work_dir)
 


### PR DESCRIPTION
Pull out the hardcoded project list into command line argument.

---

This is a big step towards making this project more universal. Tested in "dry mode":

```
❱❱❱ podman run -it --rm -v .:/bot:ro localhost/fedora-bot /bot/fedora_bot.py --component osbuild:3 --component osbuild-composer:2 --component koji-osbuild:2

--- osbuild ---

Info: Checking for open pull requests of osbuild...
OK: There are currently no open pull requests for osbuild.
Info: Checking for missing updates of 'osbuild'...
      Cloning into 'https://src.fedoraproject.org/rpms/osbuild.git'...
      Checked out dist-git with branch 'rawhide'
      Version osbuild 56 found in dist-git
      Fedora 35: ✅ Build for osbuild 56 is available in Koji
      Fedora 35: ✅ Update for osbuild 56 is available in Bodhi
      Fedora 34: ✅ Build for osbuild 56 is available in Koji
      Fedora 34: ✅ Update for osbuild 56 is available in Bodhi
      Fedora 36: ✅ Build for osbuild 56 is available in Koji
      Fedora 36: ✅ Update for osbuild 56 is available in Bodhi
OK: No releases found with missing updates.

--- osbuild-composer ---

Info: Checking for open pull requests of osbuild-composer...
OK: There are currently no open pull requests for osbuild-composer.
Info: Checking for missing updates of 'osbuild-composer'...
      Cloning into 'https://src.fedoraproject.org/rpms/osbuild-composer.git'...
      Checked out dist-git with branch 'rawhide'
      Version osbuild-composer 51 found in dist-git
      Fedora 35: ✅ Build for osbuild-composer 51 is available in Koji
      Fedora 35: ✅ Update for osbuild-composer 51 is available in Bodhi
      Fedora 34: ✅ Build for osbuild-composer 51 is available in Koji
      Fedora 34: ✅ Update for osbuild-composer 51 is available in Bodhi
      Fedora 36: ✅ Build for osbuild-composer 51 is available in Koji
      Fedora 36: ✅ Update for osbuild-composer 51 is available in Bodhi
OK: No releases found with missing updates.

--- koji-osbuild ---

Info: Checking for open pull requests of koji-osbuild...
OK: There are currently no open pull requests for koji-osbuild.
Info: Checking for missing updates of 'koji-osbuild'...
      Cloning into 'https://src.fedoraproject.org/rpms/koji-osbuild.git'...
      Checked out dist-git with branch 'rawhide'
      Version koji-osbuild 6 found in dist-git
      Fedora 35: ✅ Build for koji-osbuild 6 is available in Koji
      Fedora 35: ✅ Update for koji-osbuild 6 is available in Bodhi
      Fedora 34: ✅ Build for koji-osbuild 6 is available in Koji
      Fedora 34: ✅ Update for koji-osbuild 6 is available in Bodhi
      Fedora 36: ✅ Build for koji-osbuild 6 is available in Koji
      Fedora 36: ✅ Update for koji-osbuild 6 is available in Bodhi
OK: No releases found with missing updates.

```