### PR TITLE
Move container to GitHub container registry

### DIFF
--- a/.github/workflows/build-bot-container.yml
+++ b/.github/workflows/build-bot-container.yml
@@ -10,22 +10,25 @@ jobs:
   build-and-publish:
     name: Publish container image
     runs-on: 'ubuntu-latest'
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
 
-      - name: Login to Quay.io
+      - name: Login to container registry
         uses: docker/login-action@v1
         with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_REGISTRY_USER }}
-          password: ${{ secrets.QUAY_REGISTRY_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          build-args: BUILDER_SRC=github.com/osbuild/fedora-bot
+          build-args: BUILDER_SRC=github.com/${{ github.repository }}
           push: true
           file: Dockerfile
-          tags: quay.io/osbuild/fedora-bot:latest
+          tags: ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/poll-releases.yml
+++ b/.github/workflows/poll-releases.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: quay.io/osbuild/fedora-bot:latest
+      image: ghcr.io/osbuild/fedora-bot:latest
 
     steps:
       - name: Check out the repo

--- a/.github/workflows/reminder-bot.yml
+++ b/.github/workflows/reminder-bot.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: quay.io/osbuild/fedora-bot:latest
+      image: ghcr.io/osbuild/fedora-bot:latest
 
     steps:
       - name: Check out the repo
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: quay.io/osbuild/fedora-bot:latest
+      image: ghcr.io/osbuild/fedora-bot:latest
 
     steps:
       - name: Check out the repo


### PR DESCRIPTION
The container is built and run on GitHub, so it makes more sense to also
host it on GitHub. This also gets rid of a project secret (as the
default GitHub token is sufficient for this), and makes it easier to
test changes on forks.

----

I tested this on my fork: Without any further modification, I [ran the workflow](https://github.com/martinpitt/fedora-bot/runs/6482525489?check_suite_focus=true), and it [built a container image](https://github.com/martinpitt/fedora-bot/pkgs/container/fedora-bot):

```
❱❱❱ podman run -it --rm  ghcr.io/martinpitt/fedora-bot:latest
Trying to pull ghcr.io/martinpitt/fedora-bot:latest...
Getting image source signatures
Copying blob 98d28a431257 done  
Copying blob 736fb53cfb11 done  
Copying blob de72a73b45a4 done  
Copying config d4d17383d2 done  
Writing manifest to image destination
Storing signatures
[root@dcfd03f09794 /]# 
```