### PR TITLE
workflows: Use plain commands for building and pushing the container

### DIFF
--- a/.github/workflows/build-bot-container.yml
+++ b/.github/workflows/build-bot-container.yml
@@ -17,18 +17,11 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
 
-      - name: Login to container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build container
+        run: podman build -t ghcr.io/${{ github.repository }}:latest .
 
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          build-args: BUILDER_SRC=github.com/${{ github.repository }}
-          push: true
-          file: Dockerfile
-          tags: ghcr.io/${{ github.repository }}:latest
+      - name: Login to container registry
+        run: podman login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
+
+      - name: Push container to registry
+        run: podman push ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
Running third-party actions should be done with caution, as they have a
lot of access to your project and can be changed/captured at any time.
There is no reason right now to mistrust these actions, but at the same
time they don't really buy us anything: Running the commands directly is
shorter, easier to understand, and easier to debug locally.

---

Tested on my fork: [workflow run](https://github.com/martinpitt/fedora-bot/runs/6505322868?check_suite_focus=true), [container image](https://github.com/martinpitt/fedora-bot/pkgs/container/fedora-bot):
```
$ podman run -it --rm -v .:/bot:ro ghcr.io/martinpitt/fedora-bot /bot/fedora_bot.py -c umockdev:2
[...]
Info: Checking for missing updates of 'umockdev'...
      Cloning into 'https://src.fedoraproject.org/rpms/umockdev.git'...
      Checked out dist-git with branch 'rawhide'
      Version umockdev 0.17.10 found in dist-git
      Fedora 35: ✅ Build for umockdev 0.17.10 is available in Koji
      Fedora 35: ✅ Update for umockdev 0.17.10 is available in Bodhi
      Fedora 36: ✅ Build for umockdev 0.17.10 is available in Koji
      Fedora 36: ✅ Update for umockdev 0.17.10 is available in Bodhi
Info: WARNING: There is no build for umockdev 0.17.10 in Fedora 34. Probably packit is still doing its thing...
OK: No releases found with missing updates.
```