### PR TITLE
fedora-bot: Fix --component parsing

### DIFF
--- a/fedora_bot.py
+++ b/fedora_bot.py
@@ -292,8 +292,9 @@ def main():
     for component_numtests in args.component:
         try:
             component, num_tests = component_numtests.split(':')
-        except AttributeError:
-            parser.error(f"Invalid component format, must be PACKAGE:NUM_TESTS: {component_numtests}")
+            num_tests = int(num_tests)
+        except ValueError:
+            parser.error(f"Invalid component format, must be PACKAGE:NUM_TESTS : {component_numtests}")
 
         print(f"\n--- {component} ---\n")
         msg_info(f"Checking for open pull requests of {component}...")


### PR DESCRIPTION
Commit 548103a2b55 introduced a bug: `num_tests` was a string, so the
comparison tried to compare a number to a string:

    Info: Only 2/2 tests have run, let's try again later.

Convert it to a number during the parsing to fix that:

    OK: All 2 tests passed so the pull-request can be merged.

Also fix the error mode: If the string is not in the expected format,
both split() and int() will raise a `ValueError`, not an
`AttributeError`.