### PR TITLE
fedora_bot: Don't treat pending tests as success

### DIFF
--- a/fedora_bot.py
+++ b/fedora_bot.py
@@ -106,11 +106,13 @@ def check_pull_request_flags(component, pr_id, num_tests):
 
     if len(test_results) != num_tests: # check if the expected number of tests passed
         msg_info(f"Only {len(test_results)}/{num_tests} tests have run, let's try again later.")
-    elif 'failure' not in test_results:
+    elif all(r == 'success' for r in test_results):
         msg_ok(f"All {len(test_results)} tests passed so the pull-request can be merged.")
         success = True
     elif 'failure' in test_results:
         msg_info(f"Pull request '{pr_id}' has {len(test_results)}/{num_tests} failed tests and therefore cannot be auto-merged.")
+    elif 'pending' in test_results:
+        msg_info(f"Some tests are still running, let's try again later")
     else:
         msg_error("Something is wrong - maybe the amount of tests have changed?")
 


### PR DESCRIPTION
`status` is a tri-state (at least). We need to treat "pending" as "retry
later", not as success. Make the success condition explicit to avoid
unknown statuses from being misinterpreted.

Also add a check for "pending" to give a sensible message.

---

Noticed on https://src.fedoraproject.org/rpms/cockpit/pull-request/52 while my test was still pending. The JSON  looked like this:

```json
{
  "flags": [
    {
      "comment": "Package tests for 5614c7b7: passed", 
      "commit_hash": "5614c7b71863b28c95dd2f77787f148f1b633822", 
      "date_created": "1653321767", 
      "date_updated": "1653322255", 
      "percent": null, 
      "status": "success", 
      "url": "https://koji.fedoraproject.org/koji/taskinfo?taskID=87410414", 
      "user": {
        "full_url": "https://src.fedoraproject.org/user/pingou", 
        "fullname": "Pierre-YvesChibon", 
        "name": "pingou", 
        "url_path": "user/pingou"
      }, 
      "username": "Fedora CI - scratch build"
    }, 
    {
      "comment": "Package tests for 5614c7b7: running", 
      "commit_hash": "5614c7b71863b28c95dd2f77787f148f1b633822", 
      "date_created": "1653322256", 
      "date_updated": "1653322256", 
      "percent": null, 
      "status": "pending", 
      "url": "https://osci-jenkins-1.ci.fedoraproject.org/job/fedora-ci/job/dist-git-pipeline/job/master/140635/", 
      "user": {
        "full_url": "https://src.fedoraproject.org/user/pingou", 
        "fullname": "Pierre-YvesChibon", 
        "name": "pingou", 
        "url_path": "user/pingou"
      }, 
      "username": "Fedora CI - dist-git test"
    }
  ]
}
```

Now it's correct:

```

Info: Checking for open pull requests of cockpit...
Info: Found 3 open pull requests for cockpit. Starting the merge train...
Info: Some tests are still running, let's try again later
Info: Some tests are still running, let's try again later
Info: Some tests are still running, let's try again later
```