### PR TITLE
workflows: fix the number of osbuild tests

### DIFF
--- a/.github/workflows/poll-releases.yml
+++ b/.github/workflows/poll-releases.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Check for new releases
-        run: python3 fedora_bot.py --user imagebuilder-bot --password "${{ secrets.FEDORA_PASSWORD }}" --apikey "${{ secrets.FEDORA_APIKEY }}" --component osbuild:1 --component osbuild-composer:1 --component koji-osbuild:1
+        run: python3 fedora_bot.py --user imagebuilder-bot --password "${{ secrets.FEDORA_PASSWORD }}" --apikey "${{ secrets.FEDORA_APIKEY }}" --component osbuild:2 --component osbuild-composer:1 --component koji-osbuild:1
         shell: bash
         env:
           SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"


### PR DESCRIPTION
Osbuild has two tests in fedora dist-git actually: Scratch build and
a small smoke test. Let's fix that.