### PR TITLE
Make inputs optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,11 +4,11 @@ description: "Check for open PRs and missing Bodhi updates"
 
 inputs:
   fedora_apikey:
-    description: "The Fedora API Key"
-    required: true
+    description: "The Fedora API Key (needed for merging PRs)"
+    required: false
   num_tests:
-    description: "How many tests to expect for Fedora CI"
-    required: true
+    description: "How many tests to expect for Fedora CI (needed for merging PRs)"
+    required: false
   fedora_username:
     description: "Valid username for src.fedoraproject.org (needed for publishing Bodhi updates)"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -3,18 +3,18 @@ name: "Fedora bot"
 description: "Check for open PRs and missing Bodhi updates"
 
 inputs:
-  fedora_username:
-    description: "Valid username for src.fedoraproject.org"
-    required: true
-  fedora_password:
-    description: "The Fedora password to the username"
-    required: true
   fedora_apikey:
     description: "The Fedora API Key"
     required: true
   num_tests:
     description: "How many tests to expect for Fedora CI"
     required: true
+  fedora_username:
+    description: "Valid username for src.fedoraproject.org (needed for publishing Bodhi updates)"
+    required: false
+  fedora_password:
+    description: "The Fedora password to the username (needed for publishing Bodhi updates)"
+    required: false
   SLACK_WEBHOOK_URL:
     description: "A Slack webhook URL to receive notifications"
     required: false


### PR DESCRIPTION
Cherry-pick updates from main and make all inputs optional.

This means that projects that only want to run Bodhi updates can do so by only supplying the `fedora_username` and `fedora_password` inputs.
If you only want to run the part of the action that merges green PRs you can do so by supplying the `fedora_apikey` and `num_tests` inputs.