### PR TITLE
Dockerfile: Install bodhi-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.fedoraproject.org/fedora:36
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-  krb5-workstation fedpkg koji \
+  krb5-workstation fedpkg koji bodhi-client \
   python3 python3-pexpect python3-cryptography python3-slackclient && \
   dnf clean all
 


### PR DESCRIPTION
https://src.fedoraproject.org/rpms/fedpkg/c/06ae89e8e6ecac85a476cb92cceba4bd187c7b57?branch=f36

removed fedora-packager from the list of dependencies of fedpkg. This resulted
in bodhi-client not being pulled. We need it though, so we have to now install
it explicitly.