### PR TITLE
reminder-bot: Disable weekly release reminders

### DIFF
--- a/.github/workflows/reminder-bot.yml
+++ b/.github/workflows/reminder-bot.yml
@@ -19,12 +19,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      - name: Check for pending reminders
-        run: python3 reminder_bot.py -r
-        shell: bash
-        env:
-          SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"
-          SLACK_NICKS_KEY: "${{ secrets.SLACK_NICKS_KEY }}"
       - name: Check for stale frontend PRs
         run: python3 reminder_bot.py -f
         shell: bash


### PR DESCRIPTION
Let's disable the weekly release reminders, as we really don't need them much anymore and they just create additional noise.

I've decided to only remove the trigger so far and keep the reminder stuff in the code so we can easily re-enable it should we find we need to.