### PR TITLE
reminder-bot: Fix frontend reminders

### DIFF
--- a/.github/workflows/reminder-bot.yml
+++ b/.github/workflows/reminder-bot.yml
@@ -24,6 +24,7 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"
+          SLACK_NICKS_KEY: "${{ secrets.SLACK_NICKS_KEY }}"
   monthly:
     if: contains(github.event.schedule, '0 8 1 * *')
     name: Monthly reminder


### PR DESCRIPTION
When we don't pass the secret the slack_nicks var is empty so the workflow will crash.