### PR TITLE
CI: push the built container also to quay.io

### DIFF
--- a/.github/workflows/build-bot-container.yml
+++ b/.github/workflows/build-bot-container.yml
@@ -18,10 +18,17 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build container
-        run: podman build -t ghcr.io/${{ github.repository }}:latest .
+        run: podman build -t ghcr.io/${{ github.repository }}:latest -t quay.io/${{ github.repository }}:latest .
 
-      - name: Login to container registry
+      - name: Authenticate to GHCR
         run: podman login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
-      - name: Push container to registry
+      - name: Authenticate to Quay
+        run: podman login -u ${{ secrets.QUAY_REGISTRY_USER }} -p ${{ secrets.QUAY_REGISTRY_PASSWORD }} quay.io
+
+      - name: Push container to GHCR
         run: podman push ghcr.io/${{ github.repository }}:latest
+
+      # This is needed for centos-bot (downstream) to be able to pull the image
+      - name: Push container to Quay
+        run: podman push quay.io/${{ github.repository }}:latest


### PR DESCRIPTION
[1] changed the Github action to push the fedora-bot image only to GHCR, instead of Quay.io. While this looked sensible, this broke our downstream release workflow. Specifically a private version of this bot called centos-bot is using the fedora-bot container image as a base image and builds on it. And it pulls the image from the Quay.io.

The [1] change silently broke our downstream workflow and we are still using a F34 build of the fedora-bot container.

Push the built container to both, GHCR and Quay.io.

[1] https://github.com/osbuild/fedora-bot/commit/2d53757659c247140bdf389786de592f8b90bd79

Signed-off-by: Tomáš Hozza <thozza@redhat.com>