### PR TITLE
Limit cron schedule

### DIFF
--- a/.github/workflows/poll-releases.yml
+++ b/.github/workflows/poll-releases.yml
@@ -1,10 +1,11 @@
-# Poll for new releases in Fedora dist-git and schedule Koji builds and/or update Bodhi
+# Poll for new pull requests in Fedora dist-git auto-merge when green
 name: "Fedora bot"
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: '*/30 * * * *'
+    # Every 30mins between 8AM and 3PM on Wednesdays
+    - cron: '*/30 8-15 * * 3'
 
 jobs:
   check:

--- a/README.md
+++ b/README.md
@@ -2,12 +2,8 @@
 
 This is a very simplistic bot (`fedora_bot.py`) that periodically runs and checks for new releases of osbuild or osbuild-composer.
 
-If it finds a new release it:
-
- * merges open pull requests created by Packit
- * schedules builds in Koji (to be replaced by Packit)
- * updates Bodhi (to be replaced by Packit)
+It looks for open pull requests created by Packit. It then checks whether CI has passed and if so, merges the pull request.
 
  # Reminder Bot
 
- The reminder bot (`reminder_bot.py`) sends notifications to the team's Slack channel about whose turn it is to be a foreperson.
+The reminder bot (`reminder_bot.py`) sends notifications to the team's Slack channel about whose turn it is to be a foreperson.


### PR DESCRIPTION
Currently, we do excessive polling of pagure: every 30mins every day.

Since our releases are scheduled to always run on Wednesdays, let's rely on that fact and define an ample enough window for PRs to get caught. This means that when releasing on any other day (e.g. manually), one needs to trigger the bot, merge the pagure PRs manually or wait until the next Wednesday.

Note that while this removes quite some wasteful cycles, there's a risk for PRs in pagure getting stuck "until the next Wednesday".