### PR TITLE
reminder-bot: Remove monthly reminder

### DIFF
--- a/.github/workflows/reminder-bot.yml
+++ b/.github/workflows/reminder-bot.yml
@@ -5,11 +5,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 8 * * *'
-    - cron: '0 8 1 * *'
 
 jobs:
   weekly:
-    if: github.event.schedule != '0 8 1 * *'
     name: Daily and weekly reminders
     runs-on: ubuntu-latest
 
@@ -25,20 +23,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"
           SLACK_NICKS_KEY: "${{ secrets.SLACK_NICKS_KEY }}"
-  monthly:
-    if: contains(github.event.schedule, '0 8 1 * *')
-    name: Monthly reminder
-    runs-on: ubuntu-latest
 
-    container:
-      image: ghcr.io/osbuild/fedora-bot:latest
-
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
-      - name: Check for pending reminders
-        run: python3 reminder_bot.py -m
-        shell: bash
-        env:
-          SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"
-          SLACK_NICKS_KEY: "${{ secrets.SLACK_NICKS_KEY }}"


### PR DESCRIPTION
Monthly reminder job is deprecated and is failing once a month. There is no reason to keep it anymore.