### PR TITLE
fedora_bot: print full exception traceback

### DIFF
--- a/fedora_bot.py
+++ b/fedora_bot.py
@@ -3,10 +3,12 @@
 """Just a small bot to take care of Koji builds and Bodhi updates"""
 
 import argparse
-import subprocess
-import sys
 import os
 import re
+import subprocess
+import sys
+import traceback
+
 import pexpect
 import requests
 from requests.adapters import HTTPAdapter, Retry
@@ -337,9 +339,10 @@ def main():
                     msg_ok("No releases found with missing updates.")
             else:
                 msg_info("No Fedora credentials supplied - skipping Bodhi updates.")
-        except Exception as error:
+        except Exception:
             print(f"Failure in processing component [{component}] - skipping")
-            print(f"Exception: {error=}, {type(error)=}")
+            print("Traceback:")
+            print(traceback.format_exc())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, the bot would log quite unhelpful messages in case any exception has been caught, such as:
```
Exception: error=KeyError('message'), type(error)=<class 'KeyError'>
```

This is less useful than printing the whole exception traceback, so let's do that instead if an exception is raised.