### PR TITLE
fedora_bot: make PR merge response parsing more robust

### DIFF
--- a/fedora_bot.py
+++ b/fedora_bot.py
@@ -158,7 +158,8 @@ def merge_pull_request(http, args, component, pr_id):
 
     req = http.post(f'https://src.fedoraproject.org/api/0/rpms/{component}/pull-request/{pr_id}/merge', headers={'Authorization': f'token {args.apikey}'})
     res = req.json()
-    if res['message'] == "Changes merged!":
+    message = res.get('message')
+    if message == "Changes merged!":
         msg_ok(f"Merged pull request for {component}: {url}")
     else:
         msg_info(res)


### PR DESCRIPTION
It seems that the response, when merging a MR in Fedora Pagure, may not include the 'message' property. In such case, the bot will fail with a traceback due to KeyError and won't log the received message.

Make the code more robust when accessing the response and print the whole response in case it was not in an expected format.