### PR TITLE
fedora-bot: don't exit() on errors

### DIFF
--- a/fedora_bot.py
+++ b/fedora_bot.py
@@ -6,7 +6,6 @@ import argparse
 import os
 import re
 import subprocess
-import sys
 import traceback
 
 import pexpect
@@ -25,9 +24,9 @@ class fg:  # pylint: disable=too-few-public-methods
 
 
 def msg_error(body):
-    """Print error and exit"""
+    """Print error and raise a RuntimeError"""
     print(f"{fg.ERROR}{fg.BOLD}Error:{fg.RESET} {body}")
-    sys.exit(1)
+    raise RuntimeError(body)
 
 
 def msg_info(body):


### PR DESCRIPTION
The bot code is written with an expectation that if any errors happen while handling an update of a specific package, an error is printed, but the code continues handling the next component in the list. However, it turns out that the msg_error() function, called by some functions, called sys.exit(1), resulting in a hard failure where it should really just continue with the next component instead.

Modify the function to raise a RuntimeError, which can be caught by the caller, instead of exiting.