### PR TITLE
fedora-bot: improve error handling when processing component PRs

### DIFF
--- a/fedora_bot.py
+++ b/fedora_bot.py
@@ -184,9 +184,12 @@ def merge_open_pull_requests(args, component, num_tests):
     msg_info(f"Found {res['total_requests']} open pull requests for {component}. Starting the merge train...")
 
     for pr in res['requests']:
-        successful_checks = check_pull_request_flags(http, component, pr['id'], num_tests)
-        if successful_checks:
-            merge_pull_request(http, args, component, pr['id'])
+        try:
+            successful_checks = check_pull_request_flags(http, component, pr['id'], num_tests)
+            if successful_checks:
+                merge_pull_request(http, args, component, pr['id'])
+        except RuntimeError as err:
+            msg_info(f"Skipping pull request {pr['id']} for {component} due to error: {err}")
 
 
 def update_bodhi(args, component, fedora):

--- a/fedora_bot.py
+++ b/fedora_bot.py
@@ -139,16 +139,18 @@ def check_pull_request_flags(http, component, pr_id, num_tests):
         test_results.append(flag['status'])
 
     if len(test_results) != num_tests: # check if the expected number of tests passed
-        msg_info(f"Only {len(test_results)}/{num_tests} tests have run, let's try again later.")
+        msg_info(f"Pull request '{pr_id}' has {len(test_results)} test results, but expected {num_tests}.")
     elif all(r == 'success' for r in test_results):
-        msg_ok(f"All {len(test_results)} tests passed so the pull-request can be merged.")
+        msg_ok(f"Pull request '{pr_id}' has passed all tests and can be auto-merged.")
         success = True
     elif 'failure' in test_results:
-        msg_info(f"Pull request '{pr_id}' has {len(test_results)}/{num_tests} failed tests and therefore cannot be auto-merged.")
+        msg_info(f"Pull request '{pr_id}' has failed tests and therefore cannot be auto-merged.")
     elif 'pending' in test_results:
-        msg_info("Some tests are still running, let's try again later")
+        msg_info(f"Pull request '{pr_id}' has tests that are still pending and therefore cannot be auto-merged.")
+    elif 'error' in test_results:
+        msg_info(f"Pull request '{pr_id}' has tests with errors and therefore cannot be auto-merged.")
     else:
-        msg_error("Something is wrong - maybe the amount of tests have changed?")
+        msg_error(f"Pull request '{pr_id}' has unexpected test results: {res['flags']}")
 
     return success
 


### PR DESCRIPTION
- fedora-bot: handle 'error' status in PR test results 
- fedora-bot: handle RuntimeError when processing component PRs